### PR TITLE
fix: オクターブチェンジ > < のパースエラーを修正

### DIFF
--- a/src/audio/synthesizer.rs
+++ b/src/audio/synthesizer.rs
@@ -49,6 +49,8 @@ impl Synthesizer {
                     samples.extend(vec![0.0; num_samples]);
                 }
                 Command::Octave(o) => octave = o.value,
+                Command::OctaveUp => octave = octave.saturating_add(1).min(8),
+                Command::OctaveDown => octave = octave.saturating_sub(1).max(1),
                 Command::Tempo(t) => bpm = t.value,
                 Command::DefaultLength(l) => default_length = l.value,
                 Command::Volume(v) => current_velocity = v.value,

--- a/src/mml/ast.rs
+++ b/src/mml/ast.rs
@@ -8,6 +8,8 @@ pub enum Command {
     Note(Note),
     Rest(Rest),
     Octave(Octave),
+    OctaveUp,
+    OctaveDown,
     Tempo(Tempo),
     DefaultLength(DefaultLength),
     Volume(Volume),

--- a/src/mml/mod.rs
+++ b/src/mml/mod.rs
@@ -18,6 +18,8 @@ pub enum Token {
     Dot,
     Number(u16),
     Octave,
+    OctaveUp,
+    OctaveDown,
     Tempo,
     Length,
     Volume,
@@ -104,6 +106,18 @@ pub fn tokenize(input: &str) -> Result<Vec<TokenWithPos>, ParseError> {
             'R' => {
                 chars.next();
                 let tok = TokenWithPos::new(Token::Rest, position);
+                position += 1;
+                tok
+            }
+            '>' => {
+                chars.next();
+                let tok = TokenWithPos::new(Token::OctaveUp, position);
+                position += 1;
+                tok
+            }
+            '<' => {
+                chars.next();
+                let tok = TokenWithPos::new(Token::OctaveDown, position);
                 position += 1;
                 tok
             }
@@ -281,5 +295,30 @@ mod tests {
         let tokens = tokenize("C D").unwrap();
         assert_eq!(tokens[0].position, 0);
         assert_eq!(tokens[1].position, 2);
+    }
+
+    #[test]
+    fn tokenize_octave_up() {
+        let tokens = tokenize(">").unwrap();
+        assert_eq!(tokens.len(), 2);
+        assert_eq!(tokens[0].token, Token::OctaveUp);
+    }
+
+    #[test]
+    fn tokenize_octave_down() {
+        let tokens = tokenize("<").unwrap();
+        assert_eq!(tokens.len(), 2);
+        assert_eq!(tokens[0].token, Token::OctaveDown);
+    }
+
+    #[test]
+    fn tokenize_octave_change_in_mml() {
+        let tokens = tokenize("C >C <C").unwrap();
+        assert_eq!(tokens.len(), 6);
+        assert_eq!(tokens[0].token, Token::Pitch(Pitch::C));
+        assert_eq!(tokens[1].token, Token::OctaveUp);
+        assert_eq!(tokens[2].token, Token::Pitch(Pitch::C));
+        assert_eq!(tokens[3].token, Token::OctaveDown);
+        assert_eq!(tokens[4].token, Token::Pitch(Pitch::C));
     }
 }

--- a/src/mml/parser.rs
+++ b/src/mml/parser.rs
@@ -39,6 +39,14 @@ impl Parser {
             Token::Pitch(_) => Ok(Command::Note(self.parse_note()?)),
             Token::Rest => Ok(Command::Rest(self.parse_rest()?)),
             Token::Octave => Ok(Command::Octave(self.parse_octave()?)),
+            Token::OctaveUp => {
+                self.advance();
+                Ok(Command::OctaveUp)
+            }
+            Token::OctaveDown => {
+                self.advance();
+                Ok(Command::OctaveDown)
+            }
             Token::Tempo => Ok(Command::Tempo(self.parse_tempo()?)),
             Token::Length => Ok(Command::DefaultLength(self.parse_length()?)),
             Token::Volume => Ok(Command::Volume(self.parse_volume()?)),
@@ -348,5 +356,30 @@ mod tests {
             }
             _ => panic!("Expected InvalidNumber"),
         }
+    }
+
+    #[test]
+    fn parse_octave_up() {
+        let mml = parse(">").unwrap();
+        assert_eq!(mml.commands.len(), 1);
+        assert!(matches!(mml.commands[0], Command::OctaveUp));
+    }
+
+    #[test]
+    fn parse_octave_down() {
+        let mml = parse("<").unwrap();
+        assert_eq!(mml.commands.len(), 1);
+        assert!(matches!(mml.commands[0], Command::OctaveDown));
+    }
+
+    #[test]
+    fn parse_octave_change_with_notes() {
+        let mml = parse("C >C <C").unwrap();
+        assert_eq!(mml.commands.len(), 5);
+        assert!(matches!(mml.commands[0], Command::Note(_)));
+        assert!(matches!(mml.commands[1], Command::OctaveUp));
+        assert!(matches!(mml.commands[2], Command::Note(_)));
+        assert!(matches!(mml.commands[3], Command::OctaveDown));
+        assert!(matches!(mml.commands[4], Command::Note(_)));
     }
 }


### PR DESCRIPTION
## 概要
Closes #39

## Root Cause Analysis（根本原因分析）

### 原因
Tokenizer/Parser で `>` `<` 文字が未定義だったため、`UnexpectedCharacter` エラーが発生していた。

### 修正内容
- `Token` に `OctaveUp`/`OctaveDown` を追加
- tokenizer で `>` `<` を認識するように修正
- AST に `Command::OctaveUp`/`Command::OctaveDown` を追加
- Parser で `OctaveUp`/`OctaveDown` をパース
- Synthesizer で octave を +1/-1 (範囲1-8でクランプ)

**修正行数**: 76行（4ファイル）

### 影響範囲
MMLパース処理のみ。既存機能に影響なし。
**デグレードリスク**: 低

## Regression Test
- `tokenize_octave_up`: `>` トークン化
- `tokenize_octave_down`: `<` トークン化
- `tokenize_octave_change_in_mml`: MML内でのオクターブチェンジ
- `parse_octave_up`: `>` パース
- `parse_octave_down`: `<` パース
- `parse_octave_change_with_notes`: ノートと組み合わせたオクターブチェンジ

修正前: ❌ `UnexpectedCharacter` エラー
修正後: ✅ 正常に再生

## Bugfix Rule遵守チェック
- [x] 最小変更の原則（リファクタリングなし）
- [x] Regression Test追加（6テスト）
- [x] 原因記録
- [x] 影響範囲確認（全96テスト通過）