### PR TITLE
feat: メトロノームミックス機能を実装 (F-015/016/017)

### DIFF
--- a/src/audio/synthesizer.rs
+++ b/src/audio/synthesizer.rs
@@ -177,7 +177,6 @@ impl Synthesizer {
 
         // 2. クリックサンプル生成
         let click_samples = generate_noise_click(sample_rate, volume);
-        let click_len = click_samples.len();
 
         // 3. ミックス処理
         let mut position = 0;


### PR DESCRIPTION
## 概要

メトロノームサンプルを演奏サンプルにミックスする機能 `mix_metronome` を実装しました。

Closes #31

## 変更内容

- `Synthesizer::mix_metronome(&self, samples, sample_rate, bpm, beat, volume)` メソッドを追加
- クリックタイミング計算（`beat_interval_seconds` を使用）
- 各タイミングでクリック音を加算ミックス
- ユニットテスト3件を追加
  - クリック位置の確認（4ビート @120BPM → 先頭と0.5秒後）
  - 加算ミックス性の検証
  - 16ビート vs 4ビートのクリック数比較

## テスト結果

- 105テスト全パス
- Clippy警告なし

## 関連Issue

- Epic: #27
- 依存先: #28, #29, #30 (完了済み)

## 備考

- `synthesize()` への統合と `normalize_samples()` 呼び出しは、CLIオプション追加（#35）と同時に行う予定です