### PR TITLE
docs: v2.0リリースに伴うドキュメント更新

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] - 2026-01-12
+
+### Added
+
+- **メトロノーム機能**: ノイズベースのクリック音生成
+  - `--metronome` フラグでメトロノームを有効化
+  - `--metronome-beat` で4/8/16ビートを選択
+  - `--metronome-volume` で音量調節（0.0〜1.0）
+- **音声ノーマライゼーション**: クリッピング防止機能
+- **E2E統合テスト基盤**: `assert_cmd`を使用したCLIテスト
+- **CLI-Backend対応マトリクス**: 機能対応状況のドキュメント化
+
+### Changed
+
+- **履歴保存タイミング**: ループ再生時も再生前に履歴を保存するよう変更
+
+### Removed
+
+- **`--bpm`オプション**: MML内の`T`コマンドに統合（Breaking Change）
+  - 移行方法: `--bpm 180` → MML内に`T180`を記述
+
 ## [0.1.0] - 2026-01-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 
 - **再生**: MML文字列をターミナルから直接再生
 - **波形選択**: サイン波、ノコギリ波、矩形波から選択
+- **メトロノーム**: ノイズベースのクリック音で練習をサポート（v2.0新機能）
 - **履歴管理**: SQLiteによる永続的な演奏履歴の管理
 - **エクスポート**: 演奏をWAVファイルとして出力
 
@@ -45,8 +46,11 @@ cargo install --path .
 # Cメジャースケールを再生
 sine-mml play "CDEFGAB >C"
 
-# ノコギリ波でテンポ180で再生
+# ノコギリ波でテンポ180で再生（テンポはMML内のTコマンドで指定）
 sine-mml play "T180 L8 O5 C D E F G A B >C" --waveform sawtooth
+
+# メトロノーム付きで再生（v2.0新機能）
+sine-mml play "T120 CDEFGAB" --metronome --metronome-beat 8 --metronome-volume 0.5
 
 # 履歴を表示
 sine-mml history
@@ -59,6 +63,8 @@ sine-mml export --history-id 1 --output my_music.wav
 ```
 
 詳細な使い方は [USAGE.md](USAGE.md) を参照してください。
+
+> **v2.0移行ノート**: `--bpm`オプションは削除されました。テンポはMML内の`T`コマンドで指定してください（例: `T140 CDEFGAB`）。
 
 ---
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -49,10 +49,13 @@ sine-mml play <MML文字列> [オプション]
 |-----------|-------|------|-----------|
 | `--waveform` | `-w` | 波形タイプ（sine/sawtooth/square） | sine |
 | `--volume` | `-v` | 音量（0.0〜1.0） | 1.0 |
-| `--bpm` | `-b` | テンポ（30〜300） | 120 |
 | `--loop-play` | - | ループ再生（Ctrl+Cで停止） | false |
 | `--metronome` | - | メトロノーム音を追加 | false |
+| `--metronome-beat` | - | メトロノームのビート（4/8/16） | 4 |
+| `--metronome-volume` | - | メトロノームの音量（0.0〜1.0） | 0.5 |
 | `--history-id` | - | 履歴IDから再生 | - |
+
+> **Note**: v2.0で`--bpm`オプションは削除されました。テンポはMML内の`T`コマンドで指定してください（例: `T140`）。
 
 ### 使用例
 
@@ -66,14 +69,17 @@ sine-mml play "CDEFGAB" --waveform sawtooth
 # 音量を半分にして再生
 sine-mml play "CDEFGAB" --volume 0.5
 
-# テンポ180で再生
-sine-mml play "CDEFGAB" --bpm 180
+# テンポ180で再生（MML内のTコマンドで指定）
+sine-mml play "T180 CDEFGAB"
 
 # ループ再生（Ctrl+Cで停止）
 sine-mml play "CDEFGAB" --loop-play
 
 # 矩形波、音量0.3、テンポ200で再生
-sine-mml play "CDEFGAB" -w square -v 0.3 -b 200
+sine-mml play "T200 CDEFGAB" -w square -v 0.3
+
+# メトロノーム付きで再生（8ビート、音量0.3）
+sine-mml play "T120 CDEFGAB" --metronome --metronome-beat 8 --metronome-volume 0.3
 
 # 履歴ID 5 を再生
 sine-mml play --history-id 5
@@ -308,6 +314,26 @@ rm -rf ~/.local/share/sine-mml/
 # または
 rm -rf ~/Library/Application\ Support/sine-mml/
 ```
+
+---
+
+## v2.0 移行ガイド
+
+### `--bpm`オプションの廃止
+
+v2.0で`--bpm`オプションは削除されました。テンポはMML内の`T`コマンドで指定してください。
+
+**Before (v1.x)**:
+```bash
+sine-mml play "CDEFGAB" --bpm 180
+```
+
+**After (v2.0)**:
+```bash
+sine-mml play "T180 CDEFGAB"
+```
+
+この変更により、MML文字列が自己完結的になり、履歴からの再生時も同じテンポで再生されます。
 
 ---
 


### PR DESCRIPTION
## Summary

v2.0リリースに向けたドキュメントの包括的な更新。

Closes #34

## 変更内容

### README.md
- メトロノーム機能を概要セクションに追加
- クイックスタートにメトロノーム使用例を追加
- v2.0移行ノート（`--bpm`削除）を追加

### USAGE.md
- `--bpm`オプションを削除し、注記を追加
- `--metronome-beat`と`--metronome-volume`オプションを追加
- 使用例を更新（テンポはMML内Tコマンドで指定）
- v2.0移行ガイドセクションを追加

### CHANGELOG.md
- v2.0.0の変更履歴を追加
  - Added: メトロノーム機能、音声ノーマライゼーション、E2Eテスト基盤、CLI-Backend対応マトリクス
  - Changed: 履歴保存タイミング
  - Removed: `--bpm`オプション

## Checklist

- [x] ドキュメントの内容が正確である
- [x] 移行ガイドが分かりやすい
- [x] 全ての新機能がドキュメント化されている