### PR TITLE
feat: ループ用トークン追加 ([, ], :)

### DIFF
--- a/src/mml/mod.rs
+++ b/src/mml/mod.rs
@@ -46,7 +46,7 @@ impl TokenWithPos {
     }
 }
 
-#[allow(clippy::missing_errors_doc, clippy::missing_panics_doc)]
+#[allow(clippy::missing_errors_doc, clippy::missing_panics_doc, clippy::too_many_lines)]
 pub fn tokenize(input: &str) -> Result<Vec<TokenWithPos>, ParseError> {
     let mut tokens = Vec::new();
     let mut chars = input.chars().peekable();


### PR DESCRIPTION
## 概要

MMLループ構文のためのトークン（`[`, `]`, `:`）をトークナイザーに追加。

Closes #56

## 変更内容

### Token enum拡張
- `LoopStart` - ループ開始 `[`
- `LoopEnd` - ループ終了 `]`
- `LoopEscape` - ループ脱出ポイント `:`

### トークナイザー更新
- `[`, `]`, `:` を認識してトークン生成

### ユニットテスト追加
- `tokenize_loop_start` - 単体 `[` のトークン化
- `tokenize_loop_end` - 単体 `]` のトークン化
- `tokenize_loop_escape` - 単体 `:` のトークン化
- `tokenize_simple_loop` - `[CDE]3` のトークン化
- `tokenize_loop_with_escape` - `[CD:EF]2` のトークン化
- `tokenize_loop_positions` - 位置情報の正確性

## テスト結果

- ✅ 138 unit tests passed
- ✅ 8 integration tests passed
- ✅ Clippy warnings: 0

## 受け入れ条件

- [x] `[`, `]`, `:` がトークンとして認識される
- [x] 既存のトークナイズ処理に影響を与えない
- [x] ユニットテスト追加