### PR TITLE
feat: 全履歴削除コマンド (clear-history) を追加

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -14,6 +14,8 @@ pub enum Command {
     Play(PlayArgs),
     History,
     Export(ExportArgs),
+    /// Clear all playback history
+    ClearHistory,
 }
 
 #[derive(Args, Debug)]

--- a/src/cli/handlers.rs
+++ b/src/cli/handlers.rs
@@ -233,6 +233,13 @@ fn export_logic(db: &db::Database, args: &ExportArgs) -> Result<()> {
     Ok(())
 }
 
+pub fn clear_history_handler() -> Result<()> {
+    let db = db::Database::init()?;
+    let deleted = db.clear_all().context("履歴の削除に失敗しました")?;
+    output::success(&format!("✓ {deleted}件の履歴を削除しました"));
+    Ok(())
+}
+
 fn truncate_mml(mml: &str, max_len: usize) -> String {
     if mml.len() <= max_len {
         mml.to_string()

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,8 @@
 use clap::Parser;
 use sine_mml::cli::args::{Cli, Command};
-use sine_mml::cli::handlers::{export_handler, history_handler, play_handler};
+use sine_mml::cli::handlers::{
+    clear_history_handler, export_handler, history_handler, play_handler,
+};
 use sine_mml::cli::output;
 
 fn main() {
@@ -10,6 +12,7 @@ fn main() {
         Command::Play(args) => play_handler(args),
         Command::History => history_handler(),
         Command::Export(args) => export_handler(args),
+        Command::ClearHistory => clear_history_handler(),
     };
 
     if let Err(e) = result {


### PR DESCRIPTION
## 概要
`clear-history` サブコマンドを追加し、全ての再生履歴を削除する機能を実装しました。

Closes #62

## 変更内容
| ファイル | 変更内容 |
|---------|---------|
| `src/cli/args.rs` | `ClearHistory` サブコマンド追加 |
| `src/db/mod.rs` | `clear_all()` メソッド追加 |
| `src/cli/handlers.rs` | `clear_history_handler()` 追加 |
| `src/main.rs` | コマンドディスパッチ追加 |

## 使用例
```bash
sine-mml clear-history
# ✓ 81件の履歴を削除しました
```

## テスト
- ✅ 161 tests passed (新規2テスト含む)
- ✅ Clippy warnings: 0
- ✅ Smoke test: 実機確認済み

## 新規テストケース
- `test_clear_all_empty_db`: 空のDBでの削除確認
- `test_clear_all_with_entries`: エントリありの削除確認