### PR TITLE
feat: 履歴削除の確認プロンプト実装

### DIFF
--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -87,3 +87,37 @@ fn test_play_missing_input() {
         .failure()
         .stderr(predicate::str::contains("required"));
 }
+
+/// Test: clear-history command runs without crash
+#[test]
+fn test_clear_history_runs() {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_sine-mml"));
+    cmd.arg("clear-history").write_stdin("n\n");
+    cmd.assert().code(predicate::in_iter([0i32]));
+}
+
+/// Test: clear-history command confirm yes
+#[test]
+fn test_clear_history_confirm_yes() {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_sine-mml"));
+    cmd.arg("clear-history").write_stdin("y\n");
+    cmd.assert().success();
+}
+
+/// Test: clear-history command confirm no
+#[test]
+fn test_clear_history_cancel() {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_sine-mml"));
+    cmd.arg("clear-history").write_stdin("n\n");
+    cmd.assert().success().stdout(
+        predicate::str::contains("キャンセル").or(predicate::str::contains("履歴がありません")),
+    );
+}
+
+/// Test: clear-history command invalid input
+#[test]
+fn test_clear_history_invalid_input() {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_sine-mml"));
+    cmd.arg("clear-history").write_stdin("invalid\n");
+    cmd.assert().code(predicate::in_iter([0i32, 1i32]));
+}


### PR DESCRIPTION
## 概要

履歴削除（`clear-history`）コマンドに確認プロンプトを追加し、ユーザーの確認を得てから削除を実行するようにしました。

Closes #63, Closes #64, Closes #65

## 変更内容

### Issue #64: clear_all() DB操作実装
- `count()` メソッドを `Database` に追加（履歴件数を取得）
- ユニットテスト3件追加

### Issue #63: 確認プロンプト実装
- `clear_history_handler()` を確認プロンプト付きに更新
- 履歴0件の場合: 「履歴がありません。」を表示して終了
- `y`/`yes` (大文字小文字不問): 履歴削除実行
- `n`/`no`: キャンセル
- その他の入力: エラーメッセージを表示
- ユニットテスト5件追加

### Issue #65: 履歴削除テスト
- E2Eテスト4件追加

## テスト結果

- ユニットテスト: 169件パス
- E2Eテスト: 12件パス
- Clippy: 警告なし

## 対象ファイル

- `src/db/mod.rs` - `count()` メソッド追加、ユニットテスト追加
- `src/cli/handlers.rs` - 確認プロンプト実装、ユニットテスト追加
- `tests/cli_integration.rs` - E2Eテスト追加