### PR TITLE
feat: 履歴メモE2Eテストを追加 (#67)

### DIFF
--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -188,13 +188,12 @@ fn test_cli_loop_with_escape_point() {
 fn test_cli_play_with_note() {
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_sine-mml"));
     cmd.arg("play")
-        .arg("CDEF")
+        .arg("T300 L16 C")
         .arg("--note")
         .arg("My melody")
         .timeout(std::time::Duration::from_secs(5));
     cmd.assert().code(predicate::in_iter([0i32]));
 
-    // Verify history contains note
     let mut history_cmd = Command::new(env!("CARGO_BIN_EXE_sine-mml"));
     history_cmd.arg("history");
     history_cmd
@@ -208,7 +207,7 @@ fn test_cli_play_with_note() {
 fn test_cli_note_with_utf8() {
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_sine-mml"));
     cmd.arg("play")
-        .arg("CDEF")
+        .arg("T300 L16 C")
         .arg("--note")
         .arg("あいうえお🎵")
         .timeout(std::time::Duration::from_secs(5));
@@ -227,7 +226,10 @@ fn test_cli_note_with_utf8() {
 fn test_cli_note_too_long() {
     let long_note = "a".repeat(501);
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_sine-mml"));
-    cmd.arg("play").arg("CDEF").arg("--note").arg(&long_note);
+    cmd.arg("play")
+        .arg("T300 L16 C")
+        .arg("--note")
+        .arg(&long_note);
     cmd.assert()
         .failure()
         .stderr(predicate::str::contains("500"));
@@ -236,16 +238,14 @@ fn test_cli_note_too_long() {
 /// TC-025-E-004: 履歴表示でのメモ列
 #[test]
 fn test_cli_history_displays_note_column() {
-    // Play with note
     let mut cmd1 = Command::new(env!("CARGO_BIN_EXE_sine-mml"));
     cmd1.arg("play")
-        .arg("CDEF")
+        .arg("T300 L16 C")
         .arg("--note")
         .arg("Test note for display")
         .timeout(std::time::Duration::from_secs(5));
     cmd1.assert().code(predicate::in_iter([0i32]));
 
-    // Check history shows the note
     let mut history_cmd = Command::new(env!("CARGO_BIN_EXE_sine-mml"));
     history_cmd.arg("history");
     history_cmd


### PR DESCRIPTION
## 概要

履歴メモ機能のE2Eテストを実装しました。

Closes #67

## 変更内容

- --noteオプションでの再生テスト
- UTF-8メモの保存・表示テスト
- メモ長さ超過エラーテスト
- 履歴表示でのメモ列テスト

## テストケース

| TC-ID | テスト内容 | 結果 |
|-------|-----------|------|
| TC-025-E-001 | --noteオプションでの再生 | ✅ |
| TC-025-E-002 | UTF-8メモの表示 | ✅ |
| TC-025-E-003 | メモ長さ超過エラー | ✅ |
| TC-025-E-004 | 履歴表示でのメモ列 | ✅ |

## 関連Issue

- 親Issue: #50 [Epic] MML構文拡張 v2.1 (BASIC-CLI-003)
- 関連設計書: docs/designs/detailed/test-spec/REQ-CLI-003_テスト項目書.md