### PR TITLE
feat: expand_loop()の再帰対応と展開数上限チェック (#94)

### DIFF
--- a/src/mml/error.rs
+++ b/src/mml/error.rs
@@ -43,6 +43,11 @@ pub enum ParseError {
         max_depth: usize,
         position: usize,
     },
+    /// ループ展開後のコマンド数が多すぎる（最大10,000）
+    LoopExpandedTooLarge {
+        max_commands: usize,
+        actual: usize,
+    },
 }
 
 impl std::fmt::Display for ParseError {
@@ -129,6 +134,15 @@ impl std::fmt::Display for ParseError {
                 write!(
                     f,
                     "位置 {position}: ループのネストが深すぎます（最大{max_depth}階層）"
+                )
+            }
+            Self::LoopExpandedTooLarge {
+                max_commands,
+                actual,
+            } => {
+                write!(
+                    f,
+                    "ループ展開後のコマンド数が多すぎます（最大{max_commands}、実際: {actual}）"
                 )
             }
         }


### PR DESCRIPTION
## 概要

`expand_loop()` 関数に展開数上限チェックを追加し、DoS攻撃を防止します。

Closes #94

## 変更内容

### 追加
- `LoopExpandedTooLarge` エラー型を追加
- `MAX_EXPANDED_COMMANDS` 定数（10,000コマンド）を追加
- 展開数上限テスト3件を追加

### 変更
- `expand_loop()` の戻り値を `Vec<Command>` から `Result<Vec<Command>, ParseError>` に変更
- 展開中に上限チェックを実施

## ビジネスルール
- BR-080: ループ展開後のコマンド数は10,000以下
- BR-081: 脱出ポイントはネスト内でも有効

## テスト結果
- ユニットテスト: 全パス（ループ関連24件）
- Clippy: 警告なし