### PR TITLE
test(file): F-027 MMLファイル読み取りユニットテスト追加 (#105)

### DIFF
--- a/src/mml/file.rs
+++ b/src/mml/file.rs
@@ -305,9 +305,9 @@ mod tests {
         let file_path = dir.path().join("test.mml");
         let mut file = File::create(&file_path).unwrap();
         writeln!(file, "CDEF").unwrap();
-        writeln!(file, "").unwrap();
+        writeln!(file).unwrap();
         writeln!(file, "GAB").unwrap();
-        writeln!(file, "").unwrap();
+        writeln!(file).unwrap();
 
         let result = read_mml_file(file_path.to_str().unwrap());
         assert_eq!(result.unwrap(), "CDEF GAB");


### PR DESCRIPTION
## 概要
F-027 MMLファイル読み取り機能のユニットテストを追加。

## 変更内容
- `src/mml/file.rs` に3つのテストケースを追加
  - `test_read_mml_file_removes_empty_lines` (TC-027-U-003)
  - `test_read_mml_file_utf8` (TC-027-U-008)
  - `test_read_mml_file_multiline` (TC-027-U-010)

## テスト結果
- 全17テストがパス
- Clippy警告なし

## 関連Issue
Closes #105
Parent: #104

## チェックリスト
- [x] テストが全てパスする
- [x] Clippy警告なし