### PR TITLE
test(parser): F-028 相対ボリュームユニットテスト追加 (#106)

### DIFF
--- a/src/mml/parser.rs
+++ b/src/mml/parser.rs
@@ -1065,4 +1065,42 @@ mod tests {
             }
         ));
     }
+
+    // TC-028-U-009: 複数の相対値指定
+    #[test]
+    fn test_volume_multiple_relative() {
+        let input = "V5 C V+10 D V-8 E";
+        let mml = parse(input).unwrap();
+
+        // パース成功を確認（6コマンド: V5, C, V+10, D, V-8, E）
+        assert_eq!(mml.commands.len(), 6);
+
+        // V5 - 絶対値
+        assert!(matches!(
+            &mml.commands[0],
+            Command::Volume(Volume {
+                value: VolumeValue::Absolute(5)
+            })
+        ));
+
+        // V+10 - 相対値（クランプされて15になる、ただしパーサー時点では+10）
+        match &mml.commands[2] {
+            Command::Volume(Volume {
+                value: VolumeValue::Relative(delta),
+            }) => {
+                assert_eq!(*delta, 10);
+            }
+            _ => panic!("Expected Relative volume"),
+        }
+
+        // V-8 - 相対値
+        match &mml.commands[4] {
+            Command::Volume(Volume {
+                value: VolumeValue::Relative(delta),
+            }) => {
+                assert_eq!(*delta, -8);
+            }
+            _ => panic!("Expected Relative volume"),
+        }
+    }
 }


### PR DESCRIPTION
## 概要
F-028 相対ボリューム機能のユニットテストを追加。

## 変更内容
- `src/mml/parser.rs` に1つのテストケースを追加
  - `test_volume_multiple_relative` (TC-028-U-009)

## テスト結果
- 全214テストがパス
- Clippy警告なし

## 関連Issue
Closes #106
Parent: #104

## チェックリスト
- [x] テストが全てパスする
- [x] Clippy警告なし