### PR TITLE
feat(ast): Note/Rest構造体をTiedDuration型に変更

### DIFF
--- a/src/audio/synthesizer.rs
+++ b/src/audio/synthesizer.rs
@@ -311,7 +311,7 @@ pub fn generate_noise_click(sample_rate: f64, volume: f32) -> Vec<f32> {
 mod tests {
     use super::*;
     use crate::audio::waveform::WaveformType;
-    use crate::mml::{Accidental, Command, Mml, Note, Pitch, Tempo};
+    use crate::mml::{Accidental, Command, Duration, Mml, Note, Pitch, Tempo, TiedDuration};
 
     #[test]
     fn test_synthesizer_creation() {
@@ -327,8 +327,7 @@ mod tests {
         let note = Note {
             pitch: Pitch::A,
             accidental: Accidental::Natural,
-            duration: Some(4), // Quarter note
-            dots: 0,
+            duration: TiedDuration::new(Duration::new(Some(4), 0)), // Quarter note
         };
         let mml = Mml {
             commands: vec![Command::Tempo(Tempo { value: 120 }), Command::Note(note)],
@@ -542,8 +541,7 @@ mod tests {
                 Command::Note(Note {
                     pitch: Pitch::A,
                     accidental: Accidental::Natural,
-                    duration: Some(16),
-                    dots: 0,
+                    duration: TiedDuration::new(Duration::new(Some(16), 0)),
                 }),
             ],
         };
@@ -564,8 +562,7 @@ mod tests {
                 Command::Note(Note {
                     pitch: Pitch::A,
                     accidental: Accidental::Natural,
-                    duration: Some(16),
-                    dots: 0,
+                    duration: TiedDuration::new(Duration::new(Some(16), 0)),
                 }),
             ],
         };
@@ -586,8 +583,7 @@ mod tests {
                 Command::Note(Note {
                     pitch: Pitch::A,
                     accidental: Accidental::Natural,
-                    duration: Some(16),
-                    dots: 0,
+                    duration: TiedDuration::new(Duration::new(Some(16), 0)),
                 }),
             ],
         };
@@ -611,8 +607,7 @@ mod tests {
                 Command::Note(Note {
                     pitch: Pitch::A,
                     accidental: Accidental::Natural,
-                    duration: Some(16),
-                    dots: 0,
+                    duration: TiedDuration::new(Duration::new(Some(16), 0)),
                 }),
             ],
         };
@@ -636,8 +631,7 @@ mod tests {
                 Command::Note(Note {
                     pitch: Pitch::A,
                     accidental: Accidental::Natural,
-                    duration: Some(16),
-                    dots: 0,
+                    duration: TiedDuration::new(Duration::new(Some(16), 0)),
                 }),
             ],
         };
@@ -660,8 +654,7 @@ mod tests {
                 Command::Note(Note {
                     pitch: Pitch::A,
                     accidental: Accidental::Natural,
-                    duration: Some(16),
-                    dots: 0,
+                    duration: TiedDuration::new(Duration::new(Some(16), 0)),
                 }),
             ],
         };

--- a/src/mml/parser.rs
+++ b/src/mml/parser.rs
@@ -1,6 +1,6 @@
 use super::{
-    Accidental, Command, DefaultLength, Mml, Note, Octave, ParseError, Rest, Tempo, Token,
-    TokenWithPos, Volume, VolumeValue,
+    Accidental, Command, DefaultLength, Duration, Mml, Note, Octave, ParseError, Rest, Tempo,
+    TiedDuration, Token, TokenWithPos, Volume, VolumeValue,
 };
 
 const MAX_EXPANDED_COMMANDS: usize = 10_000;
@@ -232,7 +232,7 @@ impl Parser {
             Accidental::Natural
         };
 
-        let duration = if let Token::Number(_) = self.peek().token {
+        let duration_val = if let Token::Number(_) = self.peek().token {
             // Range 1-64 verified, safe to cast to u8
             #[allow(clippy::cast_possible_truncation)]
             Some(self.consume_number_in_range(1, 64)? as u8)
@@ -249,15 +249,14 @@ impl Parser {
         Ok(Note {
             pitch,
             accidental,
-            duration,
-            dots,
+            duration: TiedDuration::new(Duration::new(duration_val, dots)),
         })
     }
 
     fn parse_rest(&mut self) -> Result<Rest, ParseError> {
         self.advance(); // Consume Rest
 
-        let duration = if let Token::Number(_) = self.peek().token {
+        let duration_val = if let Token::Number(_) = self.peek().token {
             // Range 1-64 verified, safe to cast to u8
             #[allow(clippy::cast_possible_truncation)]
             Some(self.consume_number_in_range(1, 64)? as u8)
@@ -271,7 +270,9 @@ impl Parser {
             dots += 1;
         }
 
-        Ok(Rest { duration, dots })
+        Ok(Rest {
+            duration: TiedDuration::new(Duration::new(duration_val, dots)),
+        })
     }
 
     fn parse_octave(&mut self) -> Result<Octave, ParseError> {
@@ -462,8 +463,8 @@ mod tests {
             Command::Note(n) => {
                 assert_eq!(n.pitch, Pitch::C);
                 assert_eq!(n.accidental, Accidental::Natural);
-                assert_eq!(n.duration, None);
-                assert_eq!(n.dots, 0);
+                assert_eq!(n.duration.base.value, None);
+                assert_eq!(n.duration.base.dots, 0);
             }
             _ => panic!("Expected Note"),
         }
@@ -491,7 +492,7 @@ mod tests {
         match &mml.commands[0] {
             Command::Note(n) => {
                 assert_eq!(n.pitch, Pitch::C);
-                assert_eq!(n.duration, Some(4));
+                assert_eq!(n.duration.base.value, Some(4));
             }
             _ => panic!("Expected Note"),
         }
@@ -505,8 +506,8 @@ mod tests {
         match &mml.commands[0] {
             Command::Note(n) => {
                 assert_eq!(n.pitch, Pitch::C);
-                assert_eq!(n.duration, Some(4));
-                assert_eq!(n.dots, 1);
+                assert_eq!(n.duration.base.value, Some(4));
+                assert_eq!(n.duration.base.dots, 1);
             }
             _ => panic!("Expected Note"),
         }
@@ -519,8 +520,8 @@ mod tests {
         assert_eq!(mml.commands.len(), 1);
         match &mml.commands[0] {
             Command::Rest(r) => {
-                assert_eq!(r.duration, Some(4));
-                assert_eq!(r.dots, 0);
+                assert_eq!(r.duration.base.value, Some(4));
+                assert_eq!(r.duration.base.dots, 0);
             }
             _ => panic!("Expected Rest"),
         }
@@ -762,14 +763,12 @@ mod tests {
             Command::Note(Note {
                 pitch: Pitch::C,
                 accidental: Accidental::Natural,
-                duration: None,
-                dots: 0,
+                duration: TiedDuration::new(Duration::new(None, 0)),
             }),
             Command::Note(Note {
                 pitch: Pitch::D,
                 accidental: Accidental::Natural,
-                duration: None,
-                dots: 0,
+                duration: TiedDuration::new(Duration::new(None, 0)),
             }),
         ];
         let expanded = expand_loop(&commands, None, 3).unwrap();
@@ -782,20 +781,17 @@ mod tests {
             Command::Note(Note {
                 pitch: Pitch::C,
                 accidental: Accidental::Natural,
-                duration: None,
-                dots: 0,
+                duration: TiedDuration::new(Duration::new(None, 0)),
             }),
             Command::Note(Note {
                 pitch: Pitch::D,
                 accidental: Accidental::Natural,
-                duration: None,
-                dots: 0,
+                duration: TiedDuration::new(Duration::new(None, 0)),
             }),
             Command::Note(Note {
                 pitch: Pitch::E,
                 accidental: Accidental::Natural,
-                duration: None,
-                dots: 0,
+                duration: TiedDuration::new(Duration::new(None, 0)),
             }),
         ];
         let expanded = expand_loop(&commands, Some(1), 2).unwrap();
@@ -814,8 +810,7 @@ mod tests {
         let commands = vec![Command::Note(Note {
             pitch: Pitch::C,
             accidental: Accidental::Natural,
-            duration: None,
-            dots: 0,
+            duration: TiedDuration::new(Duration::new(None, 0)),
         })];
         let expanded = expand_loop(&commands, Some(0), 3).unwrap();
         assert_eq!(expanded.len(), 2);


### PR DESCRIPTION
## Summary

- Note.duration と Rest.duration を `TiedDuration` 型に変更
- タイ記法(`&`)のサポートに必要な基盤変更

## Changes

- **Note struct**: `duration: Option<u8>, dots: u8` → `duration: TiedDuration`
- **Rest struct**: `duration: Option<u8>, dots: u8` → `duration: TiedDuration`
- `Note::duration_in_seconds()` と `Rest::duration_in_seconds()` を `TiedDuration::total_duration_in_seconds()` を使うように更新
- `parser.rs` の `parse_note()` と `parse_rest()` を更新
- 全関連テストを更新

## Testing

- 全233テスト合格
- `cargo clippy -- -D warnings` 合格

Closes #122