### PR TITLE
docs: README.mdにタイ記号機能の説明を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ sine-mml play --file song.mml
 # 相対ボリュームで音量を変化（v2.1新機能）
 sine-mml play "V10 C V+2 D V-3 E"  # V10 → V12 → V9
 
+# タイ記号で音符を連結（v2.2新機能）
+sine-mml play "C4&8 D4 E4&8&16"  # C: 1.5拍、D: 1拍、E: 1.75拍
+
 # 履歴にメモを付けて再生（v2.1新機能）
 sine-mml play "CDEFGAB" --note "練習用スケール"
 


### PR DESCRIPTION
## Summary

- 概要セクションにタイ記号機能を追加
- MML構文リファレンスに`&`（タイ記号）行を追加
- 詳細な「タイ記号（v2.2新機能）」サブセクションを追加
  - 構文説明
  - 使用例: `C4&8`, `C4&8&16`, `R4&8`, `C4.&8`
  - 制約事項ドキュメント
- クイックスタートにタイ記号の例を追加

Closes #130