### PR TITLE
fix(ci): Release workflowにcontents: write権限を追加

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - 'v*.*.*'
 
+permissions:
+  contents: write
+
 jobs:
   build:
     strategy:


### PR DESCRIPTION
## 概要
Closes #139

## Root Cause Analysis（根本原因分析）

### 原因
`softprops/action-gh-release@v1` がリリースにアセットをアップロードする際、`GITHUB_TOKEN` のデフォルト権限（`contents: read`）では不足しており、`contents: write` 権限が必要。

### 修正内容
`.github/workflows/release.yml` に `permissions: contents: write` を追加。

**修正行数**: 3行（1ファイル）

### 影響範囲
Release Workflowのみ。他のワークフロー（Test, Lint, Build）には影響なし。

**デグレードリスク**: 低

## Bugfix Rule遵守チェック
- [x] 最小変更の原則（リファクタリングなし）
- [x] 原因記録
- [x] 影響範囲確認