### PR TITLE
feat: 連符用トークン定義追加（TupletStart, TupletEnd）

### DIFF
--- a/src/mml/mod.rs
+++ b/src/mml/mod.rs
@@ -474,7 +474,7 @@ mod tests {
     // 連符トークンテスト（Issue #142）
     // ============================================================
 
-    /// TC-TUP-001: TupletStart トークン単体テスト
+    /// TC-TUP-001: `TupletStart` トークン単体テスト
     #[test]
     fn tokenize_tuplet_start() {
         let tokens = tokenize("{").unwrap();


### PR DESCRIPTION
## 概要

連符構文 `{...}n` を解析するためのトークンを追加します。

## 関連Issue

Closes #142

## 変更内容

### Token enum拡張
- `Token::TupletStart` - 連符開始 `{`
- `Token::TupletEnd` - 連符終了 `}`

### トークナイザー更新
- `{` → `Token::TupletStart`
- `}` → `Token::TupletEnd`

> **注意**: `:` は既存の `Token::LoopEscape` と共用（パーサーで文脈により判別）

## テスト結果

- 全276テスト合格（新規8テスト追加）
- Clippy警告なし

### 新規テストケース
1. `tokenize_tuplet_start` - `{` 単体
2. `tokenize_tuplet_end` - `}` 単体
3. `tokenize_colon_for_tuplet` - `:` 既存トークン共用確認
4. `tokenize_simple_tuplet` - `{CDE}3` 複合
5. `tokenize_tuplet_with_base_duration` - `{CDE}3:2` ベース音長
6. `tokenize_tuplet_positions` - 位置テスト
7. `tokenize_tuplet_with_whitespace` - 空白含む
8. `tokenize_nested_tuplet` - ネスト

## 受け入れ条件

- [x] `Token::TupletStart`, `Token::TupletEnd` が定義されている
- [x] トークナイザーが `{`, `}` を正しくトークン化する
- [x] 既存テストが全て合格
- [x] 新規ユニットテスト追加