### PR TITLE
feat: 連符音長計算・シンセサイザー統合

### DIFF
--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -344,8 +344,8 @@ mod tests {
         let entry2 = HistoryEntry::new("D".to_string(), Waveform::Square, 0.6, 130, None);
 
         db.save(&entry1).unwrap();
-        // Ensure timestamp difference (macOS requires longer sleep for reliable ordering)
-        std::thread::sleep(std::time::Duration::from_millis(100));
+        // SQLite CURRENT_TIMESTAMP is second-precision; need 1s+ for reliable ordering
+        std::thread::sleep(std::time::Duration::from_secs(1));
         db.save(&entry2).unwrap();
 
         let list = db.list(None).unwrap();
@@ -367,7 +367,7 @@ mod tests {
         let entry2 = HistoryEntry::new("D".to_string(), Waveform::Square, 0.6, 130, None);
 
         db.save(&entry1).unwrap();
-        std::thread::sleep(std::time::Duration::from_millis(100));
+        std::thread::sleep(std::time::Duration::from_secs(1));
         db.save(&entry2).unwrap();
 
         let list = db.list(None).unwrap();


### PR DESCRIPTION
## Summary

- `synthesize_tuplet()` メソッドを追加し、連符の音長計算とサンプル生成を実装
- `resample_linear()` ヘルパー関数を追加し、ネストした連符のリサンプリングをサポート
- DBテストのsleep時間を1秒に増加（SQLiteのタイムスタンプ精度問題対応）

## Changes

### Synthesizer (`src/audio/synthesizer.rs`)

**synthesize_tuplet() メソッド**:
- 音長計算: `base_seconds / count`
- 音符/休符の個別音長指定対応
- オクターブ変更（`OctaveUp`, `OctaveDown`, `Octave`）対応
- ネストした連符の再帰処理とリサンプリング

**resample_linear() 関数**:
- 線形補間によるリサンプリング
- ネストした連符の時間調整に使用

**synthesize() メソッド更新**:
- `Command::Tuplet` のマッチアームを追加
- `unreachable!()` から実際の処理に変更

### Database Tests (`src/db/mod.rs`)

- `test_list_returns_descending_order`, `test_list_includes_note` のsleep時間を100msから1秒に増加
- SQLite `CURRENT_TIMESTAMP` は秒単位精度のため、確実な順序保証に1秒以上の間隔が必要

## Test Results

```
cargo test --lib
test result: ok. 314 passed; 0 failed; 0 ignored

cargo clippy -- -D warnings
Finished (no warnings)
```

### New Tests (9 cases)

- `test_synthesize_tuplet_3_notes`: 3連符の基本動作
- `test_synthesize_tuplet_with_base_duration`: ベース音長指定（`{CDE}3:2`）
- `test_synthesize_tuplet_with_rest`: 連符内の休符
- `test_synthesize_tuplet_5_notes`: 5連符
- `test_synthesize_tuplet_octave_change`: 連符内のオクターブ変更
- `test_resample_linear_upsample`: アップサンプリング
- `test_resample_linear_downsample`: ダウンサンプリング
- `test_resample_linear_empty`: 空配列処理
- `test_resample_linear_target_zero`: ターゲット0のエッジケース

## Related Issues

- Closes #145
- Part of Epic #141 (MIDIストリーミング & 連符機能 v3.0)
- Depends on #144 (parse_tuplet) - merged

## Design Document

- [バックエンド設計書](docs/designs/detailed/tuplet/バックエンド設計書.md) Section 3.5