### PR TITLE
[F-031] CLIオプション追加 (Issue #153)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,7 +38,7 @@ dependencies = [
  "alsa-sys",
  "bitflags 1.3.2",
  "libc",
- "nix",
+ "nix 0.24.3",
 ]
 
 [[package]]
@@ -186,6 +186,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -246,6 +255,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -454,6 +469,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctrlc"
+version = "3.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73736a89c4aff73035ba2ed2e565061954da00d4970fc9ac25dcc85a2a20d790"
+dependencies = [
+ "dispatch2",
+ "nix 0.30.1",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "dasp_sample"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -484,6 +510,18 @@ dependencies = [
  "option-ext",
  "redox_users",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "dispatch2"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
+dependencies = [
+ "bitflags 2.10.0",
+ "block2",
+ "libc",
+ "objc2",
 ]
 
 [[package]]
@@ -963,6 +1001,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1039,6 +1089,21 @@ dependencies = [
  "generic-array",
  "num-traits",
 ]
+
+[[package]]
+name = "objc2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c2599ce0ec54857b29ce62166b0ed9b4f6f1a70ccc9a71165b6154caca8c05"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "oboe"
@@ -1371,6 +1436,7 @@ dependencies = [
  "comfy-table",
  "console",
  "cpal",
+ "ctrlc",
  "dirs",
  "fundsp",
  "hound",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ indicatif = "0.18.3"
 console = "0.16.2"
 comfy-table = "<7.2.0"
 midir = { version = "0.9", optional = true }
+ctrlc = { version = "3.4", optional = true }
 
 [dev-dependencies]
 assert_cmd = "2.0"
@@ -32,7 +33,7 @@ tempfile = "3.8"
 
 [features]
 default = ["midi-output"]
-midi-output = ["dep:midir"]
+midi-output = ["dep:midir", "dep:ctrlc"]
 
 [[bin]]
 name = "sine-mml"


### PR DESCRIPTION
## Summary
- **--midi-out <DEVICE>**: MIDI device ID or name to output to (enables MIDI mode)
- **--midi-channel <1-16>**: MIDI channel (default: 1)
- **--midi-list**: List available MIDI devices
- Added `ctrlc` crate for Ctrl+C interrupt handling during MIDI playback
- Refactored `play_handler` for better maintainability (extracted helper functions)

## Changes
- `Cargo.toml`: Added `ctrlc` dependency (feature-gated)
- `src/cli/args.rs`: Added MIDI CLI options + 7 unit tests
- `src/cli/handlers.rs`: Added MIDI handling logic + refactored play_handler

## Usage Examples
```bash
# List MIDI devices
sine-mml play "C" --midi-list

# Play to MIDI device by ID
sine-mml play "CDEFGAB" --midi-out 0

# Play to MIDI device by name (partial match)
sine-mml play "CDEFGAB" --midi-out "IAC"

# Specify MIDI channel (drums on channel 10)
sine-mml play "C C C C" --midi-out 0 --midi-channel 10
```

## Related Issues
- Closes #153
- Part of Epic #141 (MIDIストリーミング & 連符機能 v3.0)
- Depends on: #150 (CLOSED), #151 (CLOSED), #152 (CLOSED)

## Testing
- 392 unit tests passing
- 34 integration tests passing
- 64 tie tests passing
- Clippy clean with `--all-features`