### PR TITLE
fix: add 'midi list' subcommand to list MIDI devices without MML input

### DIFF
--- a/src/cli/handlers.rs
+++ b/src/cli/handlers.rs
@@ -5,6 +5,8 @@ use anyhow::{bail, Context, Result};
 use comfy_table::Table;
 
 #[cfg(feature = "midi-output")]
+use crate::cli::args::{MidiArgs, MidiSubcommand};
+#[cfg(feature = "midi-output")]
 use crate::midi;
 
 fn determine_should_save(args: &PlayArgs) -> bool {
@@ -15,16 +17,6 @@ fn determine_should_save(args: &PlayArgs) -> bool {
     )
 }
 
-/// playサブコマンドのハンドラー
-///
-/// # Errors
-///
-/// Returns `anyhow::Result` if:
-/// - Arguments are invalid (e.g. both MML and `history_id` are missing)
-/// - MML parsing fails
-/// - Audio synthesis fails
-/// - Audio playback fails
-/// - History saving fails
 #[cfg(feature = "midi-output")]
 fn handle_midi_list() -> Result<()> {
     let devices = midi::list_midi_devices()?;
@@ -37,6 +29,14 @@ fn handle_midi_list() -> Result<()> {
         }
     }
     Ok(())
+}
+
+#[cfg(feature = "midi-output")]
+#[allow(clippy::needless_pass_by_value)]
+pub fn midi_handler(args: MidiArgs) -> Result<()> {
+    match args.command {
+        MidiSubcommand::List => handle_midi_list(),
+    }
 }
 
 #[cfg(feature = "midi-output")]
@@ -165,11 +165,6 @@ fn print_completion_message(history_id_opt: Option<i64>, note: Option<&String>) 
 
 #[allow(clippy::needless_pass_by_value)]
 pub fn play_handler(args: PlayArgs) -> Result<()> {
-    #[cfg(feature = "midi-output")]
-    if args.midi_list {
-        return handle_midi_list();
-    }
-
     let mml_string = resolve_mml_input(&args)?;
 
     if let Some(ref note) = args.note {

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,9 @@ use sine_mml::cli::handlers::{
 };
 use sine_mml::cli::output;
 
+#[cfg(feature = "midi-output")]
+use sine_mml::cli::handlers::midi_handler;
+
 fn main() {
     let cli = Cli::parse();
 
@@ -13,6 +16,8 @@ fn main() {
         Command::History => history_handler(),
         Command::Export(args) => export_handler(args),
         Command::ClearHistory => clear_history_handler(),
+        #[cfg(feature = "midi-output")]
+        Command::Midi(args) => midi_handler(args),
     };
 
     if let Err(e) = result {


### PR DESCRIPTION
## 概要
Closes #168

## Root Cause Analysis（根本原因分析）

### 原因
`--midi-list` オプションが `PlayArgs` の一部として定義されており、`PlayArgs` の `ArgGroup` で MML/history_id/file のいずれかが必須になっていたため、`--midi-list` 単独では使用できなかった。

### 修正内容
新しいサブコマンド `sine-mml midi list` を追加し、MML入力なしでMIDIデバイス一覧を表示可能にした。

**変更行数**: 42行追加、28行削除（3ファイル）

### 影響範囲
- `--midi-list` オプションは削除（breaking change）
- 新しい `midi` サブコマンドを追加

**デグレードリスク**: 低（`--midi-list` を使用していたユーザーは `midi list` に移行が必要）

## 変更内容

| ファイル | 変更 |
|---------|------|
| `src/cli/args.rs` | `Midi` コマンド、`MidiArgs`、`MidiSubcommand::List` を追加、`PlayArgs` から `--midi-list` を削除 |
| `src/cli/handlers.rs` | `midi_handler` を追加 |
| `src/main.rs` | `Midi` コマンドのルーティング追加 |

## 動作確認

```bash
# 修正前（エラー）
$ sine-mml play --midi-list
error: the following required arguments were not provided...

# 修正後（成功）
$ sine-mml midi list
MIDIデバイスが見つかりません  # または利用可能なMIDIデバイス一覧
```

## Bugfix Rule遵守チェック
- [x] 最小変更の原則（リファクタリングなし）
- [x] 原因記録
- [x] 影響範囲確認（全テスト通過）