### PR TITLE
fix: widen tolerance for flaky midi progress test

### DIFF
--- a/src/cli/output.rs
+++ b/src/cli/output.rs
@@ -187,7 +187,6 @@ mod tests {
         let interrupt = Arc::new(AtomicBool::new(false));
         let start = Instant::now();
 
-        // 別スレッドで150ms後に中断
         let interrupt_clone = Arc::clone(&interrupt);
         std::thread::spawn(move || {
             std::thread::sleep(Duration::from_millis(150));
@@ -197,9 +196,9 @@ mod tests {
         display_midi_progress(300, &interrupt);
         let elapsed = start.elapsed().as_millis();
 
-        // 約150ms付近で終了（100ms~400ms許容）
+        // CI環境ではスレッドスケジューリング遅延があるため広めの許容範囲
         assert!(
-            (100..=400).contains(&elapsed),
+            (50..=600).contains(&elapsed),
             "Expected ~150ms, got {elapsed}ms"
         );
     }


### PR DESCRIPTION
## Summary

Fix flaky test `test_display_midi_progress_short_duration` that was failing intermittently in CI (especially macOS).

## Root Cause

The test spawns a thread that sets an interrupt flag after 150ms, then asserts that the function returns within 100-400ms. In CI environments, thread scheduling delays can cause the actual elapsed time to exceed 400ms (observed: 430ms).

## Fix

Widened the acceptable range from `100..=400` to `50..=600` to accommodate CI environment variations while still verifying the interrupt mechanism works.

## Testing

```bash
cargo test test_display_midi_progress_short_duration
# 1 passed
```