### PR TITLE
fix: --versionオプションがCargo.tomlのバージョンを反映するよう修正

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -2,7 +2,7 @@ use clap::{Args, Parser, Subcommand, ValueEnum};
 
 #[derive(Parser, Debug)]
 #[command(name = "sine-mml")]
-#[command(version = "0.1.0")]
+#[command(version)]
 #[command(about = "MML Synthesizer CLI", long_about = None)]
 pub struct Cli {
     #[command(subcommand)]


### PR DESCRIPTION
## 概要
Closes #201

## Root Cause Analysis（根本原因分析）

### 原因
`src/cli/args.rs`でバージョンが`"0.1.0"`にハードコードされていた:

```rust
#[command(version = "0.1.0")]
```

### 修正内容
clapの自動バージョン取得を使用:

```rust
#[command(version)]
```

これによりCargo.tomlの`version`フィールドが自動的に使用される。

**修正行数**: 1行（1ファイル）

### 影響範囲
`--version`オプションの出力のみ。

**デグレードリスク**: 低

## 検証結果
```
$ sine-mml --version
sine-mml 0.2.2
```

## Bugfix Rule遵守チェック
- [x] 最小変更の原則（1行修正のみ）
- [x] 影響範囲確認（全テスト通過）